### PR TITLE
Added digitalReadX, digitalWriteX, pinModeX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ install(FILES ${CMAKE_BINARY_DIR}/libwiringX.so DESTINATION lib/ COMPONENT libra
 install(FILES ${CMAKE_BINARY_DIR}/libwiringX.a DESTINATION lib/ COMPONENT library)
 install(FILES ${PROJECT_SOURCE_DIR}/src/wiringX.h DESTINATION include/ COMPONENT library)
 
+install(PROGRAMS ${CMAKE_BINARY_DIR}/wiringx-pinlist DESTINATION sbin/ COMPONENT library)
 install(PROGRAMS ${CMAKE_BINARY_DIR}/wiringx-blink DESTINATION sbin/ COMPONENT library)
 install(PROGRAMS ${CMAKE_BINARY_DIR}/wiringx-interrupt DESTINATION sbin/ COMPONENT library)
 install(PROGRAMS ${CMAKE_BINARY_DIR}/wiringx-read DESTINATION sbin/ COMPONENT library)

--- a/examples/pinlist.c
+++ b/examples/pinlist.c
@@ -1,0 +1,59 @@
+/*
+	Copyright (c) 2016 CurlyMo <curlymoo1@gmail.com>
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <unistd.h>
+
+#include "wiringX.h"
+#include "../src/platform/platform.h"
+
+char *usage =
+	"Usage: %s platform\n"
+	"Example: %s raspberrypi2\n";
+
+int main(int argc, char *argv[]) {
+	char *str = NULL, *platform = NULL;
+	char usagestr[130];
+	int gpio = 0, i = 0;
+
+	memset(usagestr, '\0', 130);
+
+	// expect only 1 argument => argc must be 2
+	if(argc != 2) {
+		snprintf(usagestr, 129, usage, argv[0], argv[0]);
+		puts(usagestr);
+		return -1;
+	}
+
+	// check for a valid, numeric argument
+	platform = argv[1];
+	
+	if(wiringXSetup(platform, NULL) == -1) {
+		wiringXGC();
+		return -1;
+	}
+	
+	printf("GPIO mapping for %s\n", platform);
+	for (i=0; i<=999; i++) {
+		if(wiringXValidGPIO(i) == 0) {
+			printf("GPIO %03d => ", i);
+			str = getPinName(i);
+			if (str && *str) {
+				printf("%s\n", str);
+			} else {
+				printf("Valid but unknown\n");
+			} 
+		}
+	}
+}	
+
+	
+	

--- a/src/wiringX.c
+++ b/src/wiringX.c
@@ -298,6 +298,11 @@ int pinMode(int pin, enum pinmode_t mode) {
 	return platform->pinMode(pin, mode);
 }
 
+int pinModeX(int pin, enum pinmode_t mode) {
+	return pinMode(pin, mode);
+}
+
+
 int digitalWrite(int pin, enum digital_value_t value) {
 	if(platform == NULL) {
 		wiringXLog(LOG_ERR, "wiringX has not been properly setup (no platform has been selected)");
@@ -309,6 +314,11 @@ int digitalWrite(int pin, enum digital_value_t value) {
 	return platform->digitalWrite(pin, value);
 }
 
+int digitalWriteX(int pin, enum digital_value_t value) {
+	return digitalWrite(pin, value);
+}
+
+
 int digitalRead(int pin) {
 	if(platform == NULL) {
 		wiringXLog(LOG_ERR, "wiringX has not been properly setup (no platform has been selected)");
@@ -318,6 +328,10 @@ int digitalRead(int pin) {
 		return -1;
 	}
 	return platform->digitalRead(pin);
+}
+
+int digitalReadX(int pin) {
+	return digitalRead(pin);
 }
 
 int wiringXISR(int pin, enum isr_mode_t mode) {

--- a/src/wiringX.h
+++ b/src/wiringX.h
@@ -65,12 +65,15 @@ typedef struct wiringXSerial_t {
 void delayMicroseconds(unsigned int);
 char * getPinName(int pin) ;
 int pinMode(int, enum pinmode_t);
+int pinModeX(int, enum pinmode_t);
 int wiringXSetup(char *, void (*)(int, const char *, ...));
 int wiringXGC(void);
 
 // int analogRead(int channel);
 int digitalWrite(int, enum digital_value_t);
 int digitalRead(int);
+int digitalWriteX(int, enum digital_value_t);
+int digitalReadX(int);
 int waitForInterrupt(int, int);
 int wiringXISR(int, enum isr_mode_t);
 


### PR DESCRIPTION
Added 3 wrapper in case digitalRead, digitalWrite, pinMode already exists in a project (mainly ported from Arduino) and thus even if it can compile call are not calling the wiringX ones so I added 

- digitalReadX
- digitalWriteX
- pinModeX

This permit to explicitly call func located into wiringX library